### PR TITLE
Hotfix: Run CI after every push

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,5 @@
 on:
-  push
+  push:
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,5 @@
 on:
-  push:
-    branches: [ main ]
+  push
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - '*'
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
As we said today, during the daily meeting, we need to update the Github Actions config to run the tests workflow after each new change on any branch (so I removed the `branches` constraint).