### PR TITLE
Hotfix: Run CI after every push

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
As we said today, during the daily meeting, we need to update the Github Actions config to run the tests workflow after each new change on any branch (so I removed the `branches` constraint).

This hot fix is related to https://github.com/Clariteia/minos-pypackage/issues/1