### PR TITLE
#333 (Send `AggregateDiff` instances as events instead of `Aggregate` ones)

### DIFF
--- a/minos/common/model/declarative/aggregate/diff.py
+++ b/minos/common/model/declarative/aggregate/diff.py
@@ -43,11 +43,11 @@ class AggregateDiff(DeclarativeModel):
 
     @classmethod
     def from_difference(cls, a: Aggregate, b: Aggregate) -> AggregateDiff:
-        """Build an ``FieldsDiff`` instance from the difference of two aggregates.
+        """Build an ``AggregateDiff`` instance from the difference of two aggregates.
 
         :param a: One ``Aggregate`` instance.
         :param b: Another ``Aggregate`` instance.
-        :return: An ``FieldsDiff`` instance.
+        :return: An ``AggregateDiff`` instance.
         """
         logger.debug(f"Computing the {cls!r} between {a!r} and {b!r}...")
 
@@ -64,14 +64,23 @@ class AggregateDiff(DeclarativeModel):
 
     @classmethod
     def from_aggregate(cls, aggregate: Aggregate) -> AggregateDiff:
-        """Build an ``FieldsDiff`` from an ``Aggregate`` (considering all fields as differences).
+        """Build an ``AggregateDiff`` from an ``Aggregate`` (considering all fields as differences).
 
         :param aggregate: An ``Aggregate`` instance.
-        :return: An ``FieldsDiff`` instance.
+        :return: An ``AggregateDiff`` instance.
         """
 
         fields_diff = FieldsDiff.from_model(aggregate, ignore=["id", "version"])
         return cls(aggregate.id, aggregate.classname, aggregate.version, fields_diff)
+
+    @classmethod
+    def from_deleted_aggregate(cls, aggregate: Aggregate) -> AggregateDiff:
+        """Build an ``AggregateDiff`` from an ``Aggregate`` (considering all fields as differences).
+
+        :param aggregate: An ``Aggregate`` instance.
+        :return: An ``AggregateDiff`` instance.
+        """
+        return cls(aggregate.id, aggregate.classname, aggregate.version, FieldsDiff.empty())
 
     @classmethod
     def simplify(cls, *args: AggregateDiff) -> AggregateDiff:

--- a/minos/common/model/dynamic/diff.py
+++ b/minos/common/model/dynamic/diff.py
@@ -82,3 +82,11 @@ class FieldsDiff(DynamicModel):
         for another in args[1:]:
             current._fields |= another._fields
         return current
+
+    @classmethod
+    def empty(cls) -> FieldsDiff:
+        """Build an empty ``FieldsDiff`` instance.
+
+        :return: A ``FieldsDiff`` instance.
+        """
+        return cls(dict())

--- a/tests/test_common/test_model/test_declarative/test_aggregate/test_diff.py
+++ b/tests/test_common/test_model/test_declarative/test_aggregate/test_diff.py
@@ -50,6 +50,11 @@ class TestAggregateDiff(unittest.IsolatedAsyncioTestCase):
         observed = AggregateDiff.from_aggregate(self.initial)
         self.assertEqual(expected, observed)
 
+    def test_from_deleted_aggregate(self):
+        expected = AggregateDiff(id=1, name=Car.classname, version=1, fields_diff=FieldsDiff.empty(),)
+        observed = AggregateDiff.from_deleted_aggregate(self.initial)
+        self.assertEqual(expected, observed)
+
     def test_from_difference(self):
         expected = AggregateDiff(
             id=1,

--- a/tests/test_common/test_model/test_dynamic/test_diff.py
+++ b/tests/test_common/test_model/test_dynamic/test_diff.py
@@ -89,6 +89,9 @@ class TestAggregateDiff(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(expected, observed)
 
+    def test_empty(self):
+        self.assertEqual(FieldsDiff(dict()), FieldsDiff.empty())
+
     def test_avro_schema(self):
         expected = [
             {


### PR DESCRIPTION
Resolves #333 