### PR TITLE
#364 (`minos.common.FieldsDiff.from_difference` now accepts not hashable `ModelField` values)

### DIFF
--- a/minos/common/model/dynamic/diff.py
+++ b/minos/common/model/dynamic/diff.py
@@ -23,13 +23,11 @@ if TYPE_CHECKING:
     from ..abc import (
         Model,
     )
+    from ..fields import (
+        ModelField,
+    )
 
 logger = logging.getLogger(__name__)
-
-
-def _diff(a: dict, b: dict) -> dict:
-    d = set(a.items()) - set(b.items())
-    return dict(d)
 
 
 class FieldsDiff(BucketModel):
@@ -48,11 +46,16 @@ class FieldsDiff(BucketModel):
             ignore = list()
 
         logger.debug(f"Computing the {cls!r} between {a!r} and {b!r}...")
-        fields = _diff(a.fields, b.fields)
+        fields = cls._diff(a.fields, b.fields)
         for name in ignore:
             fields.pop(name, None)
 
         return cls(fields)
+
+    @staticmethod
+    def _diff(a: dict[str, ModelField], b: dict[str, ModelField]) -> dict[str, ModelField]:
+        d: set[(str, ModelField)] = set(a.items()) - set(b.items())
+        return dict(d)
 
     @classmethod
     def from_model(cls, aggregate: Model, ignore: Optional[list[str]] = None) -> FieldsDiff:

--- a/minos/common/model/dynamic/diff.py
+++ b/minos/common/model/dynamic/diff.py
@@ -54,8 +54,20 @@ class FieldsDiff(BucketModel):
 
     @staticmethod
     def _diff(a: dict[str, ModelField], b: dict[str, ModelField]) -> dict[str, ModelField]:
-        d: set[(str, ModelField)] = set(a.items()) - set(b.items())
-        return dict(d)
+        """Compute the difference between ``a`` and ``b``.
+
+        The implemented approach is equivalent to `dict(set(a.items()) -`set(b.items()))` but without requesting any
+        hashing assumptions.
+
+        :param a: The first dictionary of fields.
+        :param b: The second dictionary of fields.
+        :return: The differences dictionary between ``a`` and ``b``.
+        """
+
+        def _condition(key: str) -> bool:
+            return key not in b or a[key] != b[key]
+
+        return {key: a[key] for key in a if _condition(key)}
 
     @classmethod
     def from_model(cls, aggregate: Model, ignore: Optional[list[str]] = None) -> FieldsDiff:

--- a/tests/test_common/test_model/test_dynamic/test_diff.py
+++ b/tests/test_common/test_model/test_dynamic/test_diff.py
@@ -65,6 +65,14 @@ class TestFieldsDiff(unittest.IsolatedAsyncioTestCase):
         observed = FieldsDiff.from_difference(self.car_two, self.car_one, ignore=["id", "version"])
         self.assertEqual(expected, observed)
 
+    def test_with_difference_not_hashable(self):
+        expected = FieldsDiff({"values": ModelField("values", list[int], [1, 2, 3])})
+
+        model_type = ModelType.build("Foo", {"values": list[int]})
+        a, b = model_type(values=[0]), model_type(values=[1, 2, 3])
+        observed = FieldsDiff.from_difference(b, a)
+        self.assertEqual(expected, observed)
+
     def test_from_model(self):
         expected = FieldsDiff(
             {


### PR DESCRIPTION
Closes #364 