### PR TITLE
Link dependency injection with the brand new minos.cqrs

### DIFF
--- a/minos/common/launchers.py
+++ b/minos/common/launchers.py
@@ -198,6 +198,17 @@ class EntrypointLauncher(MinosSetup):
             modules += [saga]  # pragma: no cover
         except ImportError:
             pass
+
+        try:
+            # noinspection PyUnresolvedReferences
+            from minos import (
+                cqrs,
+            )
+
+            modules += [cqrs]  # pragma: no cover
+        except ImportError:
+            pass
+
         return modules
 
     async def _destroy(self) -> NoReturn:


### PR DESCRIPTION
Link dependency injection with the brand new minos.cqrs module on minos.common.EntrypointLauncher class #406