### PR TITLE
#446 (Fix bug related with `minos.common.MinosSetup.already_destroyed`)

### DIFF
--- a/minos/common/setup.py
+++ b/minos/common/setup.py
@@ -35,8 +35,23 @@ class MinosSetup(Generic[T]):
     _config: MinosConfig = Provide["config"]
 
     def __init__(self, *args, already_setup: bool = False, **kwargs):
-        self.already_setup = already_setup
-        self.already_destroyed = False
+        self._already_setup = already_setup
+
+    @property
+    def already_setup(self) -> bool:
+        """Already Setup getter.
+
+        :return: A boolean value.
+        """
+        return self._already_setup
+
+    @property
+    def already_destroyed(self) -> bool:
+        """Already Destroy getter.
+
+        :return: A boolean value.
+        """
+        return not self._already_setup
 
     @classmethod
     def from_config(cls, *args, config: MinosConfig = None, **kwargs) -> T:
@@ -66,10 +81,9 @@ class MinosSetup(Generic[T]):
 
         :return: This method does not return anything.
         """
-        if not self.already_setup:
+        if not self._already_setup:
             await self._setup()
-            self.already_setup = True
-        self.already_destroyed = False
+            self._already_setup = True
 
     async def _setup(self) -> NoReturn:
         return
@@ -82,10 +96,9 @@ class MinosSetup(Generic[T]):
 
         :return: This method does not return anything.
         """
-        if not self.already_destroyed:
+        if self._already_setup:
             await self._destroy()
-            self.already_destroyed = True
-        self.already_setup = False
+            self._already_setup = False
 
     async def _destroy(self) -> NoReturn:
         """Destroy miscellaneous repository things."""

--- a/tests/test_common/test_launchers.py
+++ b/tests/test_common/test_launchers.py
@@ -98,6 +98,9 @@ class TestEntrypointLauncher(PostgresAsyncTestCase):
         self.assertEqual(call(modules=[common]), mock.call_args)
 
     async def test_destroy(self):
+        self.launcher.injector.wire = AsyncMock()
+        await self.launcher.setup()
+
         mock = AsyncMock()
         self.launcher.injector.unwire = mock
         await self.launcher.destroy()


### PR DESCRIPTION


┆Issue is synchronized with this [ClickUp task](https://app.clickup.com/t/185w3db) by [Unito](https://www.unito.io)
