### PR TITLE
minos.common.MinosPool._check_instance must be a coroutine

### DIFF
--- a/minos/common/pools.py
+++ b/minos/common/pools.py
@@ -43,5 +43,5 @@ class MinosPool(MinosSetup, PoolBase, Generic[T], ABC):
     async def _destroy(self) -> NoReturn:
         await self.close()
 
-    def _check_instance(self, instance: T) -> bool:
+    async def _check_instance(self, instance: T) -> bool:
         return True


### PR DESCRIPTION
minos.common.MinosPool._check_instance must be a coroutine #452

┆Issue is synchronized with this [ClickUp task](https://app.clickup.com/t/18drka8) by [Unito](https://www.unito.io)
