### PR TITLE
#464 (empty set of identifiers raises an unexpected exception on `PostgreSqlSnapshot`)

### DIFF
--- a/minos/common/snapshot/pg/snapshot.py
+++ b/minos/common/snapshot/pg/snapshot.py
@@ -87,6 +87,10 @@ class PostgreSqlSnapshot(PostgreSqlSnapshotSetup, MinosSnapshot):
 
     async def _get(self, aggregate_name: str, uuids: set[UUID]) -> AsyncIterator[SnapshotEntry]:
         uniques = set(uuids)
+
+        if not len(uniques):
+            return
+
         if len(uniques) != len(uuids):
             seen = set()
             duplicated = {x for x in uuids if x in seen or seen.add(x)}

--- a/tests/test_common/test_snapshots/test_pg/test_snapshots.py
+++ b/tests/test_common/test_snapshots/test_pg/test_snapshots.py
@@ -98,6 +98,14 @@ class TestPostgreSqlSnapshot(PostgresAsyncTestCase):
         expected = {Car(3, "blue", uuid=self.uuid_2, version=2), Car(3, "blue", uuid=self.uuid_3, version=1)}
         self.assertEqual(expected, observed)
 
+    async def test_get_empty(self):
+        async with await self._populate() as repository:
+            async with PostgreSqlSnapshot.from_config(config=self.config, repository=repository) as snapshot:
+                observed = {v async for v in snapshot.get("tests.aggregate_classes.Car", set())}
+
+        expected = set()
+        self.assertEqual(expected, observed)
+
     async def test_get_raises(self):
         async with await self._populate() as repository:
             async with PostgreSqlSnapshot.from_config(config=self.config, repository=repository) as snapshot:


### PR DESCRIPTION


┆Issue is synchronized with this [ClickUp task](https://app.clickup.com/t/18dz05t) by [Unito](https://www.unito.io)
