### PR TITLE
UUID regex pattern - issue #475 

### DIFF
--- a/tests/test_common/test_constants.py
+++ b/tests/test_common/test_constants.py
@@ -5,8 +5,10 @@ This file is part of minos framework.
 
 Minos framework can not be copied and/or distributed without the express permission of Clariteia SL.
 """
-
 import unittest
+from uuid import (
+    uuid4,
+)
 
 from minos.common import (
     NULL_UUID,
@@ -19,7 +21,8 @@ class TestConstants(unittest.TestCase):
         self.assertEqual(r"00000000-0000-0000-0000-000000000000", str(NULL_UUID))
 
     def test_uuid_regex(self):
-        self.assertEqual(r"\w{8}-\w{4}-\w{4}-\w{4}-\w{12}", UUID_REGEX.pattern)
+        uuid = str(uuid4())
+        self.assertRegex(uuid, UUID_REGEX)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think this test works better since it actually tests the regex matches an `UUID`.

What do you think @garciparedes?